### PR TITLE
fix(networking/vpc): handle nested object responses that differ from requests

### DIFF
--- a/internal/services/networking_vpc/resource.go
+++ b/internal/services/networking_vpc/resource.go
@@ -195,6 +195,22 @@ func (r *NetworkingVPCResource) Read(ctx context.Context, req resource.ReadReque
 		return
 	}
 
+	// Handle returned values that differ from the request values
+	subnet, diags := data.Subnet.Value(ctx)
+	resp.Diagnostics.Append(diags...)
+	if diags.HasError() {
+		return
+	}
+	if subnet == nil {
+		resp.Diagnostics.AddError("invalid subnet", "subnet object is nil")
+		return
+	}
+	if subnet.Name.IsNull() || subnet.Name.IsUnknown() || subnet.Name.ValueString() == "" {
+		resp.Diagnostics.AddError("invalid subnet name", "subnet name is required but was not provided")
+		return
+	}
+	data.SubnetName = subnet.Name
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 


### PR DESCRIPTION
Certain request fields, such as `networking_vpc.subnet_name` are returned via a nested object `subnet.name`.

As part of the `Read` handler, we extract this value to ensure it's set correctly.