### PR TITLE
fix(resource/compute_vm): fetch boot volume size and preserve values which are not returned by the API response for os_image_name and ssh_key

### DIFF
--- a/internal/services/compute_vm/resource.go
+++ b/internal/services/compute_vm/resource.go
@@ -154,7 +154,7 @@ func (r *ComputeVMResource) Update(ctx context.Context, req resource.UpdateReque
 		return
 	}
 	bytes, _ := io.ReadAll(res.Body)
-	err = apijson.Unmarshal(bytes, &data)
+	err = apijson.UnmarshalComputed(bytes, &data)
 	if err != nil {
 		resp.Diagnostics.AddError("failed to deserialize http request", err.Error())
 		return


### PR DESCRIPTION
For `resource "nirvana_compute_vm`:

1. We return just the `boot_volume_id` and not it's size in the `GET /compute/vms/:vm_id` in the response, thus we are missing `size` value. We call the `volumes/:volume_id` endpoint to get the size.

2. We do not return `os_image_name` and `ssh_keys` in the `GET /compute/vms/:vm_id` because we cannot guarantee their state post-creation of a VM as user's can modify them and we cannot access their machine. We must assume, once set, the original configured state value is used and if changed it will trigger a replacement resource.

3. We do not return `public_ip_enabled` in the `GET /compute/vms/:vm_id` and must derive it from if `public_ip` is not empty.