### PR TITLE
fix(nks): add Operation wait support for NKS Node Pool Update

### DIFF
--- a/internal/services/nks_node_pool/resource.go
+++ b/internal/services/nks_node_pool/resource.go
@@ -133,13 +133,27 @@ func (r *NKSNodePoolResource) Update(ctx context.Context, req resource.UpdateReq
 		resp.Diagnostics.AddError("failed to serialize http request", err.Error())
 		return
 	}
-	res := new(http.Response)
-	_, err = r.client.NKS.Clusters.Pools.Update(
+	operation, err := r.client.NKS.Clusters.Pools.Update(
 		ctx,
 		data.ClusterID.ValueString(),
 		data.ID.ValueString(),
 		nks.ClusterPoolUpdateParams{},
 		option.WithRequestBody("application/json", dataBytes),
+		option.WithMiddleware(logging.Middleware(ctx)),
+	)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to make http request", err.Error())
+		return
+	}
+	if errWaitForOperation := r.waiter.Wait(ctx, r.client, operation.ID); errWaitForOperation != nil {
+		resp.Diagnostics.AddError("failed to wait for operation", errWaitForOperation.Error())
+		return
+	}
+	res := new(http.Response)
+	_, err = r.client.NKS.Clusters.Pools.Get(
+		ctx,
+		data.ClusterID.ValueString(),
+		operation.ResourceID,
 		option.WithResponseBodyInto(&res),
 		option.WithMiddleware(logging.Middleware(ctx)),
 	)


### PR DESCRIPTION
## Summary
- NKS Node Pool `Update` now uses the operation-returning API, waits for completion via `OperationWaiter`, then fetches the latest resource state with a `Get` call.
- Mirrors the pattern already applied to Create and Delete in #271.

## Test plan
- [x] Run `terraform apply` with an NKS Node Pool update to verify the operation wait completes and state is refreshed correctly.