### PR TITLE
fix(nks): wait for Operation in NKS Cluster Update

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/hashicorp/terraform-plugin-framework-validators v0.17.0
 	github.com/hashicorp/terraform-plugin-go v0.28.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
-	github.com/nirvana-labs/nirvana-go v1.79.0
+	github.com/nirvana-labs/nirvana-go v1.81.0
 	github.com/tidwall/gjson v1.18.0
 	github.com/tidwall/sjson v1.2.5
 )

--- a/go.sum
+++ b/go.sum
@@ -141,8 +141,8 @@ github.com/mitchellh/go-testing-interface v1.14.1/go.mod h1:gfgS7OtZj6MA4U1UrDRp
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
-github.com/nirvana-labs/nirvana-go v1.79.0 h1:SMWaJ3YklrSbPXZPN4G79f7L2qzelInzJbPmyl6OWxA=
-github.com/nirvana-labs/nirvana-go v1.79.0/go.mod h1:UfQZSZ7nKVjiA+NhUHZ2vheQkNrDbRSgddax28J5tL8=
+github.com/nirvana-labs/nirvana-go v1.81.0 h1:MoQL92wAGXSqAeQtycR/OJu27EPLpw7hEC4Ijz1/HsM=
+github.com/nirvana-labs/nirvana-go v1.81.0/go.mod h1:UfQZSZ7nKVjiA+NhUHZ2vheQkNrDbRSgddax28J5tL8=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/pjbgf/sha1cd v0.3.2 h1:a9wb0bp1oC2TGwStyn0Umc/IGKQnEgF0vVaZ8QF8eo4=

--- a/internal/services/nks_cluster/resource.go
+++ b/internal/services/nks_cluster/resource.go
@@ -131,12 +131,25 @@ func (r *NKSClusterResource) Update(ctx context.Context, req resource.UpdateRequ
 		resp.Diagnostics.AddError("failed to serialize http request", err.Error())
 		return
 	}
-	res := new(http.Response)
-	_, err = r.client.NKS.Clusters.Update(
+	operation, err := r.client.NKS.Clusters.Update(
 		ctx,
 		data.ID.ValueString(),
 		nks.ClusterUpdateParams{},
 		option.WithRequestBody("application/json", dataBytes),
+		option.WithMiddleware(logging.Middleware(ctx)),
+	)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to make http request", err.Error())
+		return
+	}
+	if errWaitForOperation := r.waiter.Wait(ctx, r.client, operation.ID); errWaitForOperation != nil {
+		resp.Diagnostics.AddError("failed to wait for operation", errWaitForOperation.Error())
+		return
+	}
+	res := new(http.Response)
+	_, err = r.client.NKS.Clusters.Get(
+		ctx,
+		operation.ResourceID,
 		option.WithResponseBodyInto(&res),
 		option.WithMiddleware(logging.Middleware(ctx)),
 	)


### PR DESCRIPTION
## Summary
- `ClusterService.Update` now returns an `Operation` in `nirvana-go` v1.81.0, so the NKS Cluster resource now waits on the operation and then fetches the cluster (mirroring the existing Create/Delete and `compute_vm` Update patterns).
- Bumped `github.com/nirvana-labs/nirvana-go` from v1.79.0 to v1.81.0.

## Test plan
- [ ] `go build ./...`
- [ ] `TF_ACC=1 ./scripts/test` against a real NKS cluster update

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the NKS Cluster `Update` handler to await the asynchronous operation returned by `nirvana-go` v1.81.0, then re-fetches the cluster via `Get` before writing state — exactly mirroring the existing `Create` and `Delete` patterns. It also bumps the SDK dependency from v1.79.0 to v1.81.0.

- **`internal/services/nks_cluster/resource.go`**: `Update` now captures the `Operation` returned by `Clusters.Update`, waits on it with `r.waiter.Wait`, then calls `Clusters.Get(operation.ResourceID, ...)` to populate state — replacing the previous direct-response pattern that was no longer valid with the new API signature.
- **`go.mod` / `go.sum`**: `github.com/nirvana-labs/nirvana-go` bumped from v1.79.0 to v1.81.0 to pick up the changed `ClusterService.Update` return type.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a straightforward, well-scoped fix that aligns the Update path with the already-proven Create and Delete patterns.

The Update handler now waits for the async operation and re-fetches cluster state, matching the existing Create and Delete implementations exactly. The SDK bump is narrow and purposeful, and the logic change introduces no new error paths or edge cases beyond what the rest of the resource already handles correctly.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| internal/services/nks_cluster/resource.go | Update method now correctly waits for the async Operation and re-fetches cluster state via Get, mirroring Create/Delete patterns; no issues found. |
| go.mod | nirvana-go bumped from v1.79.0 to v1.81.0 to pick up the new ClusterService.Update return type. |
| go.sum | Checksum entries updated to reflect the nirvana-go v1.81.0 bump. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant TF as Terraform
    participant R as NKSClusterResource.Update
    participant API as nirvana-go API
    participant W as OperationWaiter

    TF->>R: Update(ctx, req, resp)
    R->>R: "MarshalJSONForUpdate(*state)"
    R->>API: NKS.Clusters.Update(ctx, clusterID, params, body)
    API-->>R: "Operation{ID, ResourceID}"
    R->>W: waiter.Wait(ctx, client, operation.ID)
    W->>API: poll operation status
    API-->>W: operation complete
    W-->>R: nil
    R->>API: NKS.Clusters.Get(ctx, operation.ResourceID)
    API-->>R: http.Response (cluster JSON)
    R->>R: "apijson.UnmarshalComputed(bytes, &data)"
    R->>TF: "resp.State.Set(ctx, &data)"
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(nks): add Operation wait support to ..."](https://github.com/nirvana-labs/terraform-provider-nirvana/commit/e75b299b7a63f0ead0968c5f0ed40d43ef2285d3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31649099)</sub>

<!-- /greptile_comment -->