### PR TITLE
fix: raise nks_cluster operation wait timeout to 30 minutes

### DIFF
--- a/internal/services/nks_cluster/resource.go
+++ b/internal/services/nks_cluster/resource.go
@@ -27,7 +27,11 @@ var _ resource.ResourceWithImportState = (*NKSClusterResource)(nil)
 
 func NewResource() resource.Resource {
 	return &NKSClusterResource{
-		waiter: lib.NewOperationWaiter().WithLinearBackoff(1*time.Second, 500*time.Millisecond, 10*time.Second),
+		// Cluster provisioning brings up the full controller node set and routinely
+		// exceeds the SDK's 10 minute lib.DefaultTimeout.
+		waiter: lib.NewOperationWaiter().
+			WithTimeout(30*time.Minute).
+			WithLinearBackoff(1*time.Second, 500*time.Millisecond, 10*time.Second),
 	}
 }
 


### PR DESCRIPTION
NKS cluster creation brings up the full controller node set and routinely runs past 10 minutes. The operation waiter used lib.DefaultTimeout (10m), so `terraform apply` failed with "operation timed out after 10m0s secs" while the cluster was still provisioning server-side — leaving an orphaned cluster absent from Terraform state.

Set an explicit 30 minute timeout on the nks_cluster waiter. Polling strategy is unchanged.